### PR TITLE
Fixed bug of UserBoardRoleId in UserBoardRelation being null after accepting invitation

### DIFF
--- a/service/src/main/java/com/softserve/borda/services/impl/InvitationServiceImpl.java
+++ b/service/src/main/java/com/softserve/borda/services/impl/InvitationServiceImpl.java
@@ -41,7 +41,7 @@ public class InvitationServiceImpl implements InvitationService {
                     new UserBoardRelation();
             userBoardRelation.setBoard(invitation.getBoard());
             userBoardRelation.setUser(invitation.getReceiver());
-            userBoardRelation.setUserBoardRole(invitation.getUserBoardRole());
+            userBoardRelation.setUserBoardRoleId(invitation.getUserBoardRoleId());
             userBoardRelationService.create(userBoardRelation);
             invitation.setIsAccepted(true);
             invitationRepository.save(invitation);


### PR DESCRIPTION
Changed userBoardRelation.setUserBoardRole to userBoardRelation.setUserBoardRoleId when accepting the invitation

https://trello.com/c/YIAgu0oY/218-fix-userboardrelation-creation-from-invitation